### PR TITLE
Throttling middleware

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
   homing-pigeon:
     volumes:
-    - shared_socket:/tmp
-    - ./:/go/src/github.com/softonic/homing-pigeon
+      - shared_socket:/tmp
+      - ./:/go/src/github.com/softonic/homing-pigeon
     build:
       context: .
       dockerfile: Dockerfile
@@ -31,10 +31,10 @@ services:
       rabbit-mq:
         condition: service_healthy
   request-middleware-pass:
-    platform: linux/amd64
+    platform: linux/arm64
     volumes:
       - shared_socket:/tmp
-    image: softonic/hp-pass-middleware:0.1.0
+    image: softonic/hp-throttling:0.1.0
     environment:
       IN_SOCKET: "/tmp/hprq"
     command: ["-stderrthreshold=INFO"]
@@ -52,7 +52,7 @@ services:
       - 15672:15672
       - 5672:5672
     healthcheck:
-      test: [ "CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmqctl", "status"]
       interval: 5s
       timeout: 20s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,12 +31,14 @@ services:
       rabbit-mq:
         condition: service_healthy
   request-middleware-pass:
-    platform: linux/arm64
+    platform: linux/amd64
     volumes:
       - shared_socket:/tmp
     image: softonic/hp-throttling:0.1.0
     environment:
       IN_SOCKET: "/tmp/hprq"
+      THROTTLE_LIMIT: "10"
+      THROTTLE_BURST: "10"
     command: ["-stderrthreshold=INFO"]
   reponse-middleware-pass:
     platform: linux/amd64

--- a/send.py
+++ b/send.py
@@ -8,7 +8,7 @@ RABBITMQ_USER = 'guest'
 RABBITMQ_PASSWORD = 'guest'
 EXCHANGE_NAME = 'homing-pigeon'
 ROUTING_KEY = ''  # Leave empty or set appropriately
-MESSAGE_COUNT = 1  # Number of messages to send
+MESSAGE_COUNT = 100000  # Number of messages to send
 MESSAGE_BODY = '{"meta": { "index" : { "_index" : "test", "_id" : "1" } },"data": { "field1" : "value1" }}'
 
 def send_messages():

--- a/send.py
+++ b/send.py
@@ -1,0 +1,56 @@
+import pika
+import sys
+import time
+
+# RabbitMQ configuration
+RABBITMQ_HOST = 'localhost'
+RABBITMQ_USER = 'guest'
+RABBITMQ_PASSWORD = 'guest'
+EXCHANGE_NAME = 'homing-pigeon'
+ROUTING_KEY = ''  # Leave empty or set appropriately
+MESSAGE_COUNT = 1  # Number of messages to send
+MESSAGE_BODY = '{"meta": { "index" : { "_index" : "test", "_id" : "1" } },"data": { "field1" : "value1" }}'
+
+def send_messages():
+    try:
+        # Connect to RabbitMQ
+        connection = pika.BlockingConnection(pika.ConnectionParameters(host=RABBITMQ_HOST, credentials=pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASSWORD)))
+        channel = connection.channel()
+
+        # Declare the exchange (optional if already declared)
+        channel.exchange_declare(exchange=EXCHANGE_NAME, exchange_type='fanout', durable=True)
+
+        print(f"Starting to send {MESSAGE_COUNT} messages to exchange: {EXCHANGE_NAME}")
+
+        for i in range(1, MESSAGE_COUNT + 1):
+            # Publish message
+            channel.basic_publish(
+                exchange=EXCHANGE_NAME,
+                routing_key=ROUTING_KEY,
+                body=MESSAGE_BODY,
+                properties=pika.BasicProperties(delivery_mode=2),  # Make messages persistent
+            )
+            
+            # Print progress every 10,000 messages
+            if i % 10000 == 0:
+                print(f"Sent {i} messages...")
+
+        print(f"Successfully sent {MESSAGE_COUNT} messages.")
+
+    except KeyboardInterrupt:
+        print("Process interrupted.")
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    finally:
+        # Ensure connection is closed
+        if 'connection' in locals() and connection.is_open:
+            connection.close()
+
+if __name__ == '__main__':
+    start_time = time.time()
+    send_messages()
+    elapsed_time = time.time() - start_time
+    print(f"Time taken: {elapsed_time:.2f} seconds")


### PR DESCRIPTION
Use [hp-throttling-middleware](https://github.com/softonic/hp-throttling) instead of [hp-passthrough](https://github.com/softonic/hp-passthrough/) as an example of how middlewares can be connected to homing-pigeon.

Also, add an script to publish message in a high pace (can be used for load test).