### PR TITLE
fix: middleware message handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM golang:1.23-bookworm AS build
 RUN apt-get update \
     && apt-get install -y protobuf-compiler
 
+RUN groupadd --gid 1000 app && useradd -u 1000 -g app app
+
 WORKDIR /go/src/github.com/softonic/homing-pigeon
 
 COPY . .
@@ -12,6 +14,10 @@ RUN make build &&\
 
 FROM scratch
 
-COPY --from=build /go/src/github.com/softonic/homing-pigeon/bin/homing-pigeon /
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+COPY --chown=app:app --from=build /go/src/github.com/softonic/homing-pigeon/bin/homing-pigeon /
+
+USER app
 
 ENTRYPOINT ["/homing-pigeon", "-logtostderr"]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,15 @@ build: dep generate-proto
 stress-build: dep generate-proto
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags="-w -s" -o bin/stress-pigeon pkg/stress/main.go
 docker-build:
-	docker build -t softonic/homing-pigeon:${TAG} .
+	docker buildx create --name hp-image-builder --driver docker-container --bootstrap 2> /dev/null || true
+	docker buildx use hp-image-builder
+	docker buildx build \
+		--pull \
+		--push \
+		-f ./Dockerfile \
+		. \
+		--platform linux/arm64,linux/amd64 \
+		-t softonic/homing-pigeon:${TAG}
 mock:
 	mockery --name=WriteAdapter -r
 	mockery --name=Channel -r

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,30 +23,35 @@ services:
       ACK_BUFFER_LENGTH: "500"
       GRPC_GO_LOG_VERBOSITY_LEVEL: 99
       GRPC_GO_LOG_SEVERITY_LEVEL: info
-      REQUEST_MIDDLEWARES_SOCKET: "passthrough:///unix:///tmp/hprq"
-      RESPONSE_MIDDLEWARES_SOCKET: "passthrough:///unix:///tmp/hprp"
+      REQUEST_MIDDLEWARES_SOCKET: "passthrough:///unix:///tmp/req1"
+      RESPONSE_MIDDLEWARES_SOCKET: "passthrough:///unix:///tmp/res1"
       READ_ADAPTER: "AMQP"
       WRITE_ADAPTER: "ELASTIC"
+    command: ["-stderrthreshold=INFO"]
     depends_on:
       rabbit-mq:
         condition: service_healthy
   request-middleware-pass:
-    platform: linux/amd64
     volumes:
       - shared_socket:/tmp
-    image: softonic/hp-throttling:0.1.0
+    image: softonic/hp-pass-middleware:dev
     environment:
-      IN_SOCKET: "/tmp/hprq"
-      THROTTLE_LIMIT: "10"
-      THROTTLE_BURST: "10"
+      IN_SOCKET: "/tmp/req1"
     command: ["-stderrthreshold=INFO"]
-  reponse-middleware-pass:
-    platform: linux/amd64
+  response-middleware-pass:
     volumes:
       - shared_socket:/tmp
-    image: softonic/hp-pass-middleware:0.1.0
+    image: softonic/hp-pass-middleware:dev
     environment:
-      IN_SOCKET: "/tmp/hprp"
+      IN_SOCKET: "/tmp/res1"
+      OUT_SOCKET: "passthrough:///unix:///tmp/res2"
+    command: ["-stderrthreshold=INFO"]
+  response-middleware-pass-2:
+    volumes:
+      - shared_socket:/tmp
+    image: softonic/hp-pass-middleware:dev
+    environment:
+      IN_SOCKET: "/tmp/res2"
     command: ["-stderrthreshold=INFO"]
   rabbit-mq:
     image: rabbitmq:3.8-management

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -4,16 +4,15 @@ import (
 	"os"
 	"strconv"
 
-        // Third-party packages, with a blank line separator
-        "k8s.io/klog"
-        _ "go.uber.org/automaxprocs"
+	// Third-party packages, with a blank line separator
+	_ "go.uber.org/automaxprocs"
+	"k8s.io/klog"
 
 	"github.com/softonic/homing-pigeon/pkg/helpers"
 	"github.com/softonic/homing-pigeon/pkg/messages"
 	"github.com/softonic/homing-pigeon/pkg/middleware"
 	"github.com/softonic/homing-pigeon/pkg/readers"
 	"github.com/softonic/homing-pigeon/pkg/writers"
-
 )
 
 func main() {

--- a/pkg/middleware/interface.go
+++ b/pkg/middleware/interface.go
@@ -15,7 +15,7 @@ var (
 		"methodConfig": [{
 		  "name": [{"service": "proto.Middleware"}],
 		  "retryPolicy": {
-			  "MaxAttempts": 3,
+			  "MaxAttempts": 5,
 			  "InitialBackoff": "1s",
 			  "MaxBackoff": "9s",
 			  "BackoffMultiplier": 3.0,

--- a/pkg/middleware/interface.go
+++ b/pkg/middleware/interface.go
@@ -8,3 +8,18 @@ type Middleware interface {
 	proto.MiddlewareServer
 	Next(req *proto.Data) (*proto.Data, error)
 }
+
+var (
+	// see https://github.com/grpc/grpc/blob/master/doc/service_config.md to know more about service config
+	defaultRetryPolicy = `{
+		"methodConfig": [{
+		  "name": [{"service": "proto.Middleware"}],
+		  "retryPolicy": {
+			  "MaxAttempts": 3,
+			  "InitialBackoff": "1s",
+			  "MaxBackoff": "9s",
+			  "BackoffMultiplier": 3.0,
+			  "RetryableStatusCodes": [ "UNAVAILABLE" ]
+		  }
+		}]}`
+)

--- a/pkg/middleware/manager.go
+++ b/pkg/middleware/manager.go
@@ -48,10 +48,6 @@ func (m *MiddlwareManager) Start() {
 		klog.V(5).Infof("Sending message to proto")
 		start := time.Now()
 
-		data := &proto.Data{
-			Body: message.Body,
-		}
-
 		// wait for ready up to 12 seconds (including retries)
 		// to handle service discontinuity (external middlewares) or startup order
 		ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 12*time.Second)
@@ -59,17 +55,14 @@ func (m *MiddlwareManager) Start() {
 			Body: message.Body,
 		}, grpc.WaitForReady(true))
 		cancelTimeout()
-
 		if err != nil {
-			klog.Errorf("What happens!? %v", err)
+			klog.Errorf("Error calling middleware %v", err)
 		} else {
-			data = handleData
+			message.Body = handleData.GetBody()
 		}
 
 		elapsed := time.Since(start)
 		klog.V(5).Infof("Middlewares took %s", elapsed)
-
-		message.Body = data.GetBody()
 
 		m.OutputChannel <- message
 	}

--- a/pkg/middleware/manager.go
+++ b/pkg/middleware/manager.go
@@ -50,7 +50,7 @@ func (m *MiddlwareManager) Start() {
 
 		// wait for ready up to 12 seconds (including retries)
 		// to handle service discontinuity (external middlewares) or startup order
-		ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 12*time.Second)
+		ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 31*time.Second)
 		handleData, err := client.Handle(ctxTimeout, &proto.Data{
 			Body: message.Body,
 		}, grpc.WaitForReady(true))

--- a/pkg/middleware/unimplemented.go
+++ b/pkg/middleware/unimplemented.go
@@ -22,7 +22,7 @@ type UnimplementedMiddleware struct {
 func (b *UnimplementedMiddleware) Next(req *proto.Data) (*proto.Data, error) {
 	if b.client != nil {
 		klog.V(0).Info("processing next middleware")
-		ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 12*time.Second)
+		ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 31*time.Second)
 		nextResp, err := (*b.client).Handle(ctxTimeout, req, grpc.WaitForReady(true))
 		cancelTimeout()
 		if err != nil {

--- a/pkg/middleware/unimplemented.go
+++ b/pkg/middleware/unimplemented.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/softonic/homing-pigeon/pkg/helpers"
@@ -64,6 +65,11 @@ func (b *UnimplementedMiddleware) getInputSocket() string {
 		err := os.Remove(socket)
 		if err != nil {
 			klog.Errorf("Failed to remove socket: %v", err)
+		}
+	} else {
+		err = os.MkdirAll(filepath.Dir(socket), 0775)
+		if err != nil {
+			klog.Errorf("Error creating socket directory: %v", err)
 		}
 	}
 	return socket

--- a/send.py
+++ b/send.py
@@ -1,3 +1,5 @@
+import string
+import random
 import pika
 import sys
 import time
@@ -8,8 +10,8 @@ RABBITMQ_USER = 'guest'
 RABBITMQ_PASSWORD = 'guest'
 EXCHANGE_NAME = 'homing-pigeon'
 ROUTING_KEY = ''  # Leave empty or set appropriately
-MESSAGE_COUNT = 100000  # Number of messages to send
-MESSAGE_BODY = '{"meta": { "index" : { "_index" : "test", "_id" : "1" } },"data": { "field1" : "value1" }}'
+MESSAGE_COUNT = 10  # Number of messages to send
+MESSAGE_BODY = '{"meta": { "index" : { "_index" : "test", "_id" :"$$ID_PLACE_HOLDER" } },"data": { "field1" : "value1" }}'
 
 def send_messages():
     try:
@@ -24,13 +26,14 @@ def send_messages():
 
         for i in range(1, MESSAGE_COUNT + 1):
             # Publish message
+            messageId = ''.join(random.choices(string.ascii_letters + string.digits, k=30))
             channel.basic_publish(
                 exchange=EXCHANGE_NAME,
                 routing_key=ROUTING_KEY,
-                body=MESSAGE_BODY,
+                body=MESSAGE_BODY.replace("$$ID_PLACE_HOLDER", messageId),
                 properties=pika.BasicProperties(delivery_mode=2),  # Make messages persistent
             )
-            
+
             # Print progress every 10,000 messages
             if i % 10000 == 0:
                 print(f"Sent {i} messages...")


### PR DESCRIPTION
This PR aims to fix some issues related to middleware message handling:
- error tolerance on message handling from homing pigeon to the 1st middleware of the chain
- add a retry policy to handle external middleware service discontinuity or wait IPC process initialisation
- wait for service to be ready in case of punctual unavailability
-  middlewares implemented using unimplemented interface
  - fix: pass the next middleware response up through the chain
  - apply same retry and waitForReady policies

Additionally:
- default image user and group will be set to 1000
- multi-arch image build (arm and amd)