### PR TITLE
fix: update copied message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ docker-build:
 	docker buildx create --name hp-image-builder --driver docker-container --bootstrap 2> /dev/null || true
 	docker buildx use hp-image-builder
 	docker buildx build \
+		--provenance=true --sbom=true \
 		--pull \
 		--push \
 		-f ./Dockerfile \

--- a/pkg/writers/adapters/elasticsearch.go
+++ b/pkg/writers/adapters/elasticsearch.go
@@ -31,6 +31,9 @@ func (es *Elasticsearch) ProcessMessages(msgs *[]messages.Message) {
 
 	for i := range *msgs {
 		msg := &(*msgs)[i]
+		if msg.IsNacked() {
+			continue
+		}
 		body, err := es.decodeBody(msg.Body)
 		if err != nil {
 			klog.Errorf("Invalid Message: %s", string(msg.Body))

--- a/pkg/writers/writer.go
+++ b/pkg/writers/writer.go
@@ -55,14 +55,7 @@ func (ew *Writer) timeout(ackChannel chan<- messages.Message) {
 func (ew *Writer) trigger(ackChannel chan<- messages.Message) {
 	ew.mutex.Lock()
 
-	// filter out messages explicitly n-acked
-	writeableMessages := make([]messages.Message, 0)
-	for _, msg := range ew.msgs {
-		if !msg.IsNacked() {
-			writeableMessages = append(writeableMessages, msg)
-		}
-	}
-	ew.WriteAdapter.ProcessMessages(&writeableMessages)
+	ew.WriteAdapter.ProcessMessages(&ew.msgs)
 	ew.sendAcks(ew.msgs, ackChannel)
 	ew.msgs = make([]messages.Message, 0)
 


### PR DESCRIPTION
fix an error introduced in #29: the messages being passed to the writer adapter were actually copies (not references)