### PR TITLE
feat: increase default message size

### DIFF
--- a/pkg/middleware/interface.go
+++ b/pkg/middleware/interface.go
@@ -23,3 +23,5 @@ var (
 		  }
 		}]}`
 )
+
+var defaultMaxMessageSize = 100 * 1024 * 1024 // 100MB

--- a/pkg/middleware/manager.go
+++ b/pkg/middleware/manager.go
@@ -33,6 +33,7 @@ func (m *MiddlwareManager) Start() {
 
 	var opts []grpc.DialOption
 	opts = append(opts,
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaultMaxMessageSize), grpc.MaxCallRecvMsgSize(defaultMaxMessageSize)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(defaultRetryPolicy))
 

--- a/pkg/middleware/unimplemented.go
+++ b/pkg/middleware/unimplemented.go
@@ -49,7 +49,11 @@ func (b *UnimplementedMiddleware) Listen(middleware proto.MiddlewareServer) {
 
 	b.client = client
 
-	grpcServer := grpc.NewServer(grpc.MaxConcurrentStreams(10))
+	grpcServer := grpc.NewServer(
+		grpc.MaxConcurrentStreams(10),
+		grpc.MaxRecvMsgSize(defaultMaxMessageSize),
+		grpc.MaxSendMsgSize(defaultMaxMessageSize),
+	)
 	proto.RegisterMiddlewareServer(grpcServer, middleware)
 
 	klog.V(0).Info("Start listening")


### PR DESCRIPTION
Increase default message size (which is 4MB) to 100MB