### PR TITLE
feat: ack delete/404 not_found bulk items behind opt-in flag (TECH-2662)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,9 @@ TAG ?= dev
 generate-proto:
 	protoc -I proto/ proto/middleware.proto --go_out=plugins=grpc:proto
 dep:
-	go get -u github.com/rakyll/gotest
-	go get -u github.com/vektra/mockery/.../
-	go get -u github.com/golang/protobuf/proto
+	go install github.com/rakyll/gotest@latest
+	go install github.com/vektra/mockery/v2@latest
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.2
-	go get -u google.golang.org/grpc
 	go mod download
 build: dep generate-proto
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags="-w -s" -o bin/homing-pigeon pkg/main.go

--- a/README.md
+++ b/README.md
@@ -18,20 +18,41 @@ A few examples could be: AMQP to Elasticsearch, HTTP to MySQL, HTTP to HTTP, or 
 
 An important detail, is that the message will be forwarded from the read interface to the write interface "as is", therefore the expected format would depend on which write adapter is connected.
 
+### Message flow and ack/nack semantics
+
+```
+Reader ──> [request middlewares] ──> Writer ──> [response middlewares] ──> Reader (ack/nack)
+```
+
+Every message read from the input ends up **acked** or **nacked** back on the read adapter;
+what each of those means (delete, dead letter, retry…) is the read adapter's decision, the
+writer only reports the outcome per message.
+
+Middlewares are external gRPC services chained between the reader and the writer (request
+middlewares) and between the writer and the reader (response middlewares). They receive
+batches of messages and can transform bodies and nack messages, but they can **not** ack a
+message the writer nacked (there is no un-nack in the protocol) and they never see the
+writer's backend response (e.g. the Elasticsearch bulk response). A failing middleware call
+nacks the whole batch.
+
 ### Currently implemented interfaces
 
 #### Read interfaces
 
 ##### RabbitMQ
 
-Reader interface reads messages from a single queue and acks or (optionally) nacks the message, depending
- as the writer will indicate. All nacks will be automatically dead lettered without retrying
+Reads messages from a single queue and acks or nacks (`requeue=false`) each message as the
+writer indicates. On startup it declares the exchanges, the queue (with
+`x-dead-letter-exchange` pointing to `RABBITMQ_DLX_NAME`) and the dead letter
+exchange/queue, so all nacked messages are dead lettered without retrying.
+
+> Note: the dead letter **queue** is declared non-durable, so a large backlog lives in the
+> broker's memory.
 
 #### Write interfaces
 
 ##### Elasticsearch with bulk API
 
-Failed messages will be nacked, and successful messages will be acked.
 It supports a well defined JSON format, which of course reminds of elasticsearch Bulk API:
 
 ```json
@@ -42,6 +63,17 @@ It supports a well defined JSON format, which of course reminds of elasticsearch
 ```
 
 More info can be found at [elasticsearch's official doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)
+
+Per-message outcome:
+
+| Situation                                                                                                                     | Outcome                             |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Bulk item answered with status <= 299                                                                                          | ack                                 |
+| `delete` item answered with 404, `result: not_found` and no `error` object, with `ELASTICSEARCH_ACK_DELETE_NOT_FOUND=true`     | ack (idempotent delete, discarded)  |
+| Any other bulk item with status > 299 (including 404s carrying an `error` object, e.g. `index_not_found_exception`)            | nack                                |
+| Whole bulk request fails or answers an HTTP error status                                                                       | every message in the batch is nacked |
+| Bulk response body cannot be decoded                                                                                            | remaining messages are nacked       |
+| Message body is not valid JSON                                                                                                  | nack (never sent to Elasticsearch)  |
 
 ### Example
 
@@ -126,10 +158,12 @@ For more options see [Bulk API reference](https://www.elastic.co/guide/en/elasti
 
 ### Development
 
-To run docker build:
+To install the dev tools (`gotest`, `mockery`, `protoc-gen-go`) and download the module
+dependencies (this does not modify `go.mod`/`go.sum` — library versions always come from the
+committed files):
 
 ```bash
-make docker-build
+make dep
 ```
 
 To run the application:
@@ -138,11 +172,30 @@ To run the application:
 docker compose up -d
 ```
 
-To run tests:
+To run tests (plain `go test -race ./...` works too):
 
 ```bash
 make test
 ```
+
+To regenerate mocks (`make mock`) or the gRPC middleware protocol (`make generate-proto`,
+requires `protoc`).
+
+### Releasing
+
+CI only builds, lints and tests — it does **not** publish images. Releases are manual:
+
+1. Merge to master and tag it: `git tag vX.Y.Z && git push --tags`
+2. Publish the multi-arch image (pushes `softonic/homing-pigeon:X.Y.Z` to Docker Hub, note
+   the image tag has no `v` prefix):
+
+   ```bash
+   make docker-build TAG=X.Y.Z
+   ```
+
+3. If the deployment needs new configuration, update the
+   [Helm chart](https://github.com/softonic/homing-pigeon-chart) (published to
+   `charts.softonic.io` on merge to its master).
 
 ### Roadmap
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ For more options see [Bulk API reference](https://www.elastic.co/guide/en/elasti
 | ELASTICSEARCH_URL                    | Elasticsearch url string                                           |
 | ELASTICSEARCH_FLUSH_MAX_SIZE         | Elasticsearch flush to bulk API maximum size                       |
 | ELASTICSEARCH_FLUSH_MAX_INTERVAL_MS  | Elasticsearch flush to bulk API max interval time, in milliseconds |
+| ELASTICSEARCH_ACK_DELETE_NOT_FOUND   | When `true`, `delete` bulk items answered with `404`/`not_found` (no `error` object) are acked instead of nacked, so idempotent deletes of missing documents are not dead lettered. Defaults to `false` |
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For more options see [Bulk API reference](https://www.elastic.co/guide/en/elasti
 | ELASTICSEARCH_URL                    | Elasticsearch url string                                           |
 | ELASTICSEARCH_FLUSH_MAX_SIZE         | Elasticsearch flush to bulk API maximum size                       |
 | ELASTICSEARCH_FLUSH_MAX_INTERVAL_MS  | Elasticsearch flush to bulk API max interval time, in milliseconds |
-| ELASTICSEARCH_ACK_DELETE_NOT_FOUND   | When `true`, `delete` bulk items answered with `404`/`not_found` (no `error` object) are acked instead of nacked, so idempotent deletes of missing documents are not dead lettered. Defaults to `false` |
+| ELASTICSEARCH_ACK_DELETE_NOT_FOUND   | When `true`, `delete` bulk items answered with `404`/`not_found` (no `error` object) are acked instead of nacked, since Elasticsearch treats deleting a missing document as an idempotent success. What a nack implies (e.g. dead lettering) remains up to the read adapter. Defaults to `false` |
 
 ### Development
 

--- a/pkg/writers/adapters/elasticsearch.go
+++ b/pkg/writers/adapters/elasticsearch.go
@@ -16,9 +16,10 @@ import (
 )
 
 type Elasticsearch struct {
-	FlushMaxSize  int
-	FlushInterval time.Duration
-	Bulk          esapi.Bulk
+	FlushMaxSize      int
+	FlushInterval     time.Duration
+	Bulk              esapi.Bulk
+	AckDeleteNotFound bool
 }
 
 func (es *Elasticsearch) ProcessMessages(msgs *[]messages.Message) {
@@ -72,17 +73,29 @@ func (es *Elasticsearch) setAcksFromResponse(response esAdapter.ElasticSearchBul
 			continue
 		}
 
+		if responseItemPos >= len(response.Items) {
+			klog.Warningf("Bulk response has fewer items than sent messages, nacking message: %v", msg.Id)
+			msg.Nack()
+			continue
+		}
+
 		item := response.Items[responseItemPos].(map[string]interface{})
-		for _, data := range item {
+		for operation, data := range item {
 			values := data.(map[string]interface{})
 			status := int(values["status"].(float64))
 
-			if status > maxValidStatus {
-				klog.Warningf("Item has invalid status: %v", data)
-
-				msg.Nack()
-			} else {
+			switch {
+			case status <= maxValidStatus:
 				msg.Ack()
+			case es.AckDeleteNotFound && operation == "delete" && status == 404 && values["error"] == nil:
+				// Elasticsearch treats deleting a missing document as an
+				// idempotent success (result: not_found), so there is no
+				// point in dead-lettering the message.
+				klog.V(2).Infof("Discarding delete on missing document: %v", data)
+				msg.Ack()
+			default:
+				klog.Warningf("Item has invalid status: %v", data)
+				msg.Nack()
 			}
 		}
 		responseItemPos++
@@ -155,13 +168,19 @@ func NewElasticsearchAdapter() (WriteAdapter, error) {
 		flushMaxIntervalMs = 1000
 	}
 
+	ackDeleteNotFound, err := strconv.ParseBool(os.Getenv("ELASTICSEARCH_ACK_DELETE_NOT_FOUND"))
+	if err != nil {
+		ackDeleteNotFound = false
+	}
+
 	es, err := elasticsearch.NewClient(elasticsearch.Config{})
 	if err != nil {
 		return nil, err
 	}
 	return &Elasticsearch{
-		FlushMaxSize:  flushMaxSize,
-		FlushInterval: time.Duration(flushMaxIntervalMs) * time.Millisecond,
-		Bulk:          es.Bulk,
+		FlushMaxSize:      flushMaxSize,
+		FlushInterval:     time.Duration(flushMaxIntervalMs) * time.Millisecond,
+		Bulk:              es.Bulk,
+		AckDeleteNotFound: ackDeleteNotFound,
 	}, nil
 }

--- a/pkg/writers/adapters/elasticsearch.go
+++ b/pkg/writers/adapters/elasticsearch.go
@@ -89,9 +89,10 @@ func (es *Elasticsearch) setAcksFromResponse(response esAdapter.ElasticSearchBul
 				msg.Ack()
 			case es.AckDeleteNotFound && operation == "delete" && status == 404 && values["error"] == nil:
 				// Elasticsearch treats deleting a missing document as an
-				// idempotent success (result: not_found), so there is no
-				// point in dead-lettering the message.
-				klog.V(2).Infof("Discarding delete on missing document: %v", data)
+				// idempotent success (result: not_found), so we report the
+				// message as acked instead of letting the read adapter
+				// handle it as a failure.
+				klog.V(2).Infof("Acking delete on missing document: %v", data)
 				msg.Ack()
 			default:
 				klog.Warningf("Item has invalid status: %v", data)

--- a/pkg/writers/adapters/elasticsearch_test.go
+++ b/pkg/writers/adapters/elasticsearch_test.go
@@ -240,3 +240,212 @@ func TestBulkActionWithNoMetadata(t *testing.T) {
 	assert.Len(t, msgs, 1)
 	assert.Empty(t, msgs[0].IsNacked())
 }
+
+func TestDeleteNotFoundIsNackedByDefault(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:  0,
+		FlushInterval: 0,
+		Bulk:          bulk.getBulkFunc(),
+	}
+
+	response := esapi.Response{
+		StatusCode: 201,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("{\"errors\":false,\"items\":[{\"delete\":{\"_id\":\"123\",\"result\":\"not_found\",\"status\":404}}]}")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"delete\": {\"_id\":\"123\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 1)
+	assert.True(t, msgs[0].IsNacked())
+}
+
+func TestDeleteNotFoundIsAckedWhenAckDeleteNotFoundIsEnabled(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:      0,
+		FlushInterval:     0,
+		Bulk:              bulk.getBulkFunc(),
+		AckDeleteNotFound: true,
+	}
+
+	response := esapi.Response{
+		StatusCode: 201,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("{\"errors\":false,\"items\":[{\"delete\":{\"_id\":\"123\",\"result\":\"not_found\",\"status\":404}}]}")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"delete\": {\"_id\":\"123\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 1)
+	assert.True(t, msgs[0].IsAcked())
+}
+
+func TestDeleteNotFoundWithErrorIsNackedWhenAckDeleteNotFoundIsEnabled(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:      0,
+		FlushInterval:     0,
+		Bulk:              bulk.getBulkFunc(),
+		AckDeleteNotFound: true,
+	}
+
+	response := esapi.Response{
+		StatusCode: 201,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("{\"errors\":true,\"items\":[{\"delete\":{\"_id\":\"123\",\"error\":{\"type\":\"index_not_found_exception\",\"reason\":\"no such index [foo]\"},\"status\":404}}]}")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"delete\": {\"_id\":\"123\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 1)
+	assert.True(t, msgs[0].IsNacked())
+}
+
+func TestNonDeleteNotFoundIsNackedWhenAckDeleteNotFoundIsEnabled(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:      0,
+		FlushInterval:     0,
+		Bulk:              bulk.getBulkFunc(),
+		AckDeleteNotFound: true,
+	}
+
+	response := esapi.Response{
+		StatusCode: 201,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("{\"errors\":true,\"items\":[{\"index\":{\"_id\":\"123\",\"status\":404}}]}")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"index\": {\"_id\":\"123\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 1)
+	assert.True(t, msgs[0].IsNacked())
+}
+
+func TestBulkActionWithMixedItemStatusAndAckDeleteNotFoundEnabled(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:      0,
+		FlushInterval:     0,
+		Bulk:              bulk.getBulkFunc(),
+		AckDeleteNotFound: true,
+	}
+
+	response := esapi.Response{
+		StatusCode: 201,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("{\"errors\":true,\"items\":[{\"delete\":{\"_id\":\"1\",\"result\":\"not_found\",\"status\":404}},{\"create\":{\"_id\":\"2\",\"status\":409}},{\"create\":{\"_id\":\"3\",\"status\":200}}]}")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"delete\": {\"_id\":\"1\"}} }"),
+		},
+		{
+			Id:   1,
+			Body: []byte("{ \"meta\": {\"create\": {\"_id\":\"2\"}} }"),
+		},
+		{
+			Id:   2,
+			Body: []byte("{ \"meta\": {\"create\": {\"_id\":\"3\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 3)
+	assert.True(t, msgs[0].IsAcked())
+	assert.True(t, msgs[1].IsNacked())
+	assert.True(t, msgs[2].IsAcked())
+}
+
+func TestUndecodableBulkResponseNacksAllMessagesWithoutPanicking(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:  0,
+		FlushInterval: 0,
+		Bulk:          bulk.getBulkFunc(),
+	}
+
+	response := esapi.Response{
+		StatusCode: 200,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("this-is-not-json")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"delete\": {\"_id\":\"1\"}} }"),
+		},
+		{
+			Id:   1,
+			Body: []byte("{ \"meta\": {\"delete\": {\"_id\":\"2\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 2)
+	assert.True(t, msgs[0].IsNacked())
+	assert.True(t, msgs[1].IsNacked())
+}
+
+func TestNewElasticsearchAdapterReadsAckDeleteNotFoundFromEnv(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_ACK_DELETE_NOT_FOUND", "true")
+
+	adapter, err := NewElasticsearchAdapter()
+
+	assert.NoError(t, err)
+	assert.True(t, adapter.(*Elasticsearch).AckDeleteNotFound)
+}
+
+func TestNewElasticsearchAdapterDefaultsAckDeleteNotFoundToFalse(t *testing.T) {
+	adapter, err := NewElasticsearchAdapter()
+
+	assert.NoError(t, err)
+	assert.False(t, adapter.(*Elasticsearch).AckDeleteNotFound)
+}


### PR DESCRIPTION
## What

Ack (discard) bulk `delete` items answered by Elasticsearch with `404`/`result: not_found` instead of nacking them, behind a new opt-in env var `ELASTICSEARCH_ACK_DELETE_NOT_FOUND` (defaults to `false`, so behavior is unchanged unless enabled).

Also fixes an index-out-of-range panic in `setAcksFromResponse` when the bulk response body cannot be decoded (empty/short `items`): the affected messages are now nacked instead of crashing the writer.

## Why now

The webstorage dead letter queues (`webstorage-dl-{europe,asia,us}` × sft/dwn/fhp) have accumulated **~5M messages**, almost all of them deletes of documents that no longer exist — e.g. `{"meta":{"delete":{"_id":"…-mac-en","_index":"applications_v24_en"}},"data":null}`. The producer fans deletes out across all per-language indices, so these 404s are structural. Elasticsearch treats a delete of a missing document as an idempotent success, so dead-lettering them only buries real errors and wastes broker memory.

Strict discriminator: only `op == "delete" && status == 404 && no "error" object` is acked. A 404 that carries an `error` (e.g. `index_not_found_exception`) still dead-letters, as does any other operation with `status > 299`.

## Verification

- `go test -race -count=1 ./...` green (new tests: flag on/off × delete-404-clean / delete-404-with-error / index-404 / mixed batch / undecodable response no longer panics / env var wiring).
- With the flag unset, behavior is covered by the pre-existing tests plus a new regression test asserting delete/404 keeps nacking by default.

Jira: [TECH-2662](https://softonic-development.atlassian.net/browse/TECH-2662)


[TECH-2662]: https://softonic-development.atlassian.net/browse/TECH-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ