### PR TITLE
fix: nack messages that cannot be written to the bulk buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Per-message outcome:
 | Any other bulk item with status > 299 (including 404s carrying an `error` object, e.g. `index_not_found_exception`)            | nack                                |
 | Whole bulk request fails or answers an HTTP error status                                                                       | every message in the batch is nacked |
 | Bulk response body cannot be decoded                                                                                            | remaining messages are nacked       |
-| Message body is not valid JSON                                                                                                  | nack (never sent to Elasticsearch)  |
+| Message body is not valid JSON, or cannot be turned into a bulk line (e.g. missing `meta`)                                      | nack (never sent to Elasticsearch)  |
 
 ### Example
 

--- a/pkg/writers/adapters/elasticsearch.go
+++ b/pkg/writers/adapters/elasticsearch.go
@@ -43,6 +43,12 @@ func (es *Elasticsearch) ProcessMessages(msgs *[]messages.Message) {
 		}
 		err = es.writeToBuffer(&buf, body)
 		if err != nil {
+			// Nacking here is required for correctness, not only to report
+			// the invalid message: setAcksFromResponse skips nacked
+			// messages, so leaving it unresolved would shift the bulk
+			// response attribution for the rest of the batch.
+			klog.Errorf("Invalid Message: %s", string(msg.Body))
+			msg.Nack()
 			continue
 		}
 	}

--- a/pkg/writers/adapters/elasticsearch_test.go
+++ b/pkg/writers/adapters/elasticsearch_test.go
@@ -238,7 +238,49 @@ func TestBulkActionWithNoMetadata(t *testing.T) {
 	bulk.AssertNotCalled(t, "func1", mock.Anything)
 	bulk.AssertExpectations(t)
 	assert.Len(t, msgs, 1)
-	assert.Empty(t, msgs[0].IsNacked())
+	assert.True(t, msgs[0].IsNacked())
+}
+
+func TestMessageWithoutMetadataInBatchDoesNotShiftResponseAttribution(t *testing.T) {
+	bulk := new(BulkMock)
+	esAdapter := Elasticsearch{
+		FlushMaxSize:  0,
+		FlushInterval: 0,
+		Bulk:          bulk.getBulkFunc(),
+	}
+
+	// Only the first and last messages reach the bulk request, so the
+	// response carries two items: a failure for msg 0 and a success for
+	// msg 2. The meta-less msg 1 must not consume a response position.
+	response := esapi.Response{
+		StatusCode: 201,
+		Header:     nil,
+		Body:       io.NopCloser(strings.NewReader("{\"errors\":true,\"items\":[{\"create\":{\"_id\":\"1\",\"status\":409}},{\"create\":{\"_id\":\"3\",\"status\":200}}]}")),
+	}
+	bulk.On("func1", mock.Anything).Once().Return(&response, nil)
+
+	msgs := []messages.Message{
+		{
+			Id:   0,
+			Body: []byte("{ \"meta\": {\"create\": {\"_id\":\"1\"}} }"),
+		},
+		{
+			Id:   1,
+			Body: []byte("{ \"foobar\": {\"create\": {\"_id\":\"2\"}} }"),
+		},
+		{
+			Id:   2,
+			Body: []byte("{ \"meta\": {\"create\": {\"_id\":\"3\"}} }"),
+		},
+	}
+
+	esAdapter.ProcessMessages(&msgs)
+
+	bulk.AssertExpectations(t)
+	assert.Len(t, msgs, 3)
+	assert.True(t, msgs[0].IsNacked())
+	assert.True(t, msgs[1].IsNacked())
+	assert.True(t, msgs[2].IsAcked())
 }
 
 func TestDeleteNotFoundIsNackedByDefault(t *testing.T) {


### PR DESCRIPTION
## What

Nack messages whose body decodes fine but cannot be turned into a bulk line (e.g. missing `meta`), instead of silently skipping them. Fixes #40.

## Why now

A skipped-but-unresolved message consumed a bulk response position in `setAcksFromResponse` that belonged to the next message, so in mixed batches the attribution shifted: the meta-less message took the following item's outcome and the tail of the batch either panicked (`index out of range`, before the bounds guard from #39) or got spuriously nacked (after it). Nacked messages are excluded from response attribution, so nacking restores alignment — and an unwritable message can never be flushed anyway, reporting it as failed is consistent with the invalid-JSON path right above.

Behavior change: a lone meta-less message is now nacked by the writer itself. Previously it was left unresolved and ended up nacked anyway by the AMQP reader's fallback in `HandleAck` (an unresolved message takes the nack branch), so the observable outcome only changes for mixed batches — where it was wrong. `TestBulkActionWithNoMetadata` updated accordingly.

## Verification

- New test `TestMessageWithoutMetadataInBatchDoesNotShiftResponseAttribution` reproduces the misalignment (written first, watched fail: the meta-less message stole the next item's success and the last message got nacked with a 200).
- `go test -race -count=1 ./...` green.

Jira: [TECH-2662](https://softonic-development.atlassian.net/browse/TECH-2662) (found while working on it)


[TECH-2662]: https://softonic-development.atlassian.net/browse/TECH-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ