### PR TITLE
feat: make the middleware call timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ In order to start up correctly, it needs well defined environment variables:
 | WRITE_ADAPTER                 | Write interface implementation. Default: ELASTIC                                                     |
 | MIDDLEWARE_BATCH_SIZE         | Number of messages to send in batch to the middleware (Defaults to 50).                              |
 | MIDDLEWARE_BATCH_TIMEOUT_MS   | Max time to wait until getting a full size batch in milliseconds (Defaults to 100ms).                |
+| MIDDLEWARE_CALL_TIMEOUT_MS    | Max time to wait for a middleware call to complete, including waiting for the middleware to become reachable; on expiry the batch is nacked (Defaults to 31000ms). |
 
 ##### Read Adapters
 

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -53,6 +53,7 @@ func main() {
 
 	batchSize := helpers.GetIntEnv("MIDDLEWARE_BATCH_SIZE", 50)
 	batchTimeout := time.Duration(helpers.GetIntEnv("MIDDLEWARE_BATCH_TIMEOUT_MS", 100)) * time.Millisecond
+	callTimeout := time.Duration(helpers.GetIntEnv("MIDDLEWARE_CALL_TIMEOUT_MS", 31_000)) * time.Millisecond
 
 	requestMiddleware := middleware.NewMiddlewareManager(
 		msgChBeforeMiddleware,
@@ -60,6 +61,7 @@ func main() {
 		helpers.GetEnv("REQUEST_MIDDLEWARES_SOCKET", ""),
 		batchSize,
 		batchTimeout,
+		callTimeout,
 	)
 
 	responseMiddleware := middleware.NewMiddlewareManager(
@@ -68,6 +70,7 @@ func main() {
 		helpers.GetEnv("RESPONSE_MIDDLEWARES_SOCKET", ""),
 		batchSize,
 		batchTimeout,
+		callTimeout,
 	)
 
 	go reader.Start(ctx)

--- a/pkg/middleware/manager.go
+++ b/pkg/middleware/manager.go
@@ -17,6 +17,7 @@ type MiddlwareManager struct {
 	MiddlewareAddress string
 	BatchSize         int
 	BatchTimeout      time.Duration
+	CallTimeout       time.Duration
 }
 
 // Start starts the middleware manager.
@@ -142,7 +143,7 @@ func (m *MiddlwareManager) processMessageBatch(msgBatch []messages.Message, clie
 		}
 	}
 	// send messages with wait for the middleware to be ready
-	ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 31*time.Second)
+	ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), m.CallTimeout)
 	handleData, err := client.Handle(ctxTimeout, &proto.Data{
 		Messages: protoMsgsRequest,
 	}, grpc.WaitForReady(true))
@@ -185,12 +186,13 @@ func (m *MiddlwareManager) isMiddlewareNotAvailable() bool {
 }
 
 // NewMiddlewareManager creates a new instance of MiddlwareManager.
-func NewMiddlewareManager(inputChannel chan messages.Message, outputChannel chan messages.Message, address string, batchSize int, batchTimeout time.Duration) *MiddlwareManager {
+func NewMiddlewareManager(inputChannel chan messages.Message, outputChannel chan messages.Message, address string, batchSize int, batchTimeout time.Duration, callTimeout time.Duration) *MiddlwareManager {
 	return &MiddlwareManager{
 		InputChannel:      inputChannel,
 		OutputChannel:     outputChannel,
 		MiddlewareAddress: address,
 		BatchSize:         batchSize,
 		BatchTimeout:      batchTimeout,
+		CallTimeout:       callTimeout,
 	}
 }

--- a/pkg/middleware/manager_test.go
+++ b/pkg/middleware/manager_test.go
@@ -66,7 +66,7 @@ func TestMiddlewareManager_Start_WithoutMiddleware(t *testing.T) {
 	outputChan := make(chan messages.Message, 10)
 
 	// Create manager without middleware address
-	manager := NewMiddlewareManager(inputChan, outputChan, "", 5, time.Second)
+	manager := NewMiddlewareManager(inputChan, outputChan, "", 5, time.Second, time.Second)
 
 	// Send test messages
 	testMessages := []messages.Message{
@@ -155,7 +155,7 @@ func TestMiddlewareManager_Start_WithMiddleware_Integration(t *testing.T) {
 	outputChan := make(chan messages.Message, 10)
 
 	// Create manager with the Unix socket address
-	manager := NewMiddlewareManager(inputChan, outputChan, "unix://"+socketPath, 2, 100*time.Millisecond)
+	manager := NewMiddlewareManager(inputChan, outputChan, "unix://"+socketPath, 2, 100*time.Millisecond, time.Second)
 
 	// Send test messages
 	testMessages := []messages.Message{
@@ -222,7 +222,7 @@ func TestMiddlewareManager_GetBatch(t *testing.T) {
 		inputChan := make(chan messages.Message, 10)
 		outputChan := make(chan messages.Message, 10)
 		// Use a non-empty address to ensure this is in the "middleware available" path
-		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 100*time.Millisecond)
+		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 100*time.Millisecond, time.Second)
 
 		// Send 5 messages
 		for i := 1; i <= 5; i++ {
@@ -240,7 +240,7 @@ func TestMiddlewareManager_GetBatch(t *testing.T) {
 	t.Run("Timeout", func(t *testing.T) {
 		inputChan := make(chan messages.Message, 10)
 		outputChan := make(chan messages.Message, 10)
-		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 50*time.Millisecond)
+		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 50*time.Millisecond, time.Second)
 
 		// Send only 2 messages
 		inputChan <- messages.Message{Id: 1, Body: []byte("test1")}
@@ -256,7 +256,7 @@ func TestMiddlewareManager_GetBatch(t *testing.T) {
 	t.Run("ChannelCloseBeforeFirstMessage", func(t *testing.T) {
 		inputChan := make(chan messages.Message, 10)
 		outputChan := make(chan messages.Message, 10)
-		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 100*time.Millisecond)
+		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 100*time.Millisecond, time.Second)
 
 		close(inputChan)
 
@@ -268,7 +268,7 @@ func TestMiddlewareManager_GetBatch(t *testing.T) {
 	t.Run("ChannelCloseDuringBatch", func(t *testing.T) {
 		inputChan := make(chan messages.Message, 10)
 		outputChan := make(chan messages.Message, 10)
-		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 200*time.Millisecond)
+		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, 200*time.Millisecond, time.Second)
 
 		// Send first message and start getBatch in goroutine
 		inputChan <- messages.Message{Id: 1, Body: []byte("test1")}
@@ -318,7 +318,7 @@ func TestMiddlewareManager_ProcessMessageBatch(t *testing.T) {
 
 	inputChan := make(chan messages.Message, 10)
 	outputChan := make(chan messages.Message, 10)
-	manager := NewMiddlewareManager(inputChan, outputChan, "", 3, time.Second)
+	manager := NewMiddlewareManager(inputChan, outputChan, "", 3, time.Second, time.Second)
 
 	t.Run("SuccessfulProcessing", func(t *testing.T) {
 		// Setup mock to return processed messages
@@ -633,17 +633,61 @@ func TestMiddlewareManager_ProcessMessageBatch(t *testing.T) {
 	})
 }
 
+func TestMiddlewareManager_ProcessMessageBatch_MiddlewareUnreachable(t *testing.T) {
+	// Client pointing to a socket where nothing listens: with WaitForReady
+	// the call blocks until the call timeout expires.
+	conn, err := grpc.NewClient("unix:///tmp/hp_nonexistent_"+t.Name()+".sock",
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+	client := proto.NewMiddlewareClient(conn)
+
+	inputChan := make(chan messages.Message, 10)
+	outputChan := make(chan messages.Message, 10)
+	manager := NewMiddlewareManager(inputChan, outputChan, "unused", 3, time.Second, 300*time.Millisecond)
+
+	testMessages := []messages.Message{
+		{Id: 1, Body: []byte("test1")},
+		{Id: 2, Body: []byte("test2")},
+	}
+
+	start := time.Now()
+	manager.processMessageBatch(testMessages, client)
+	elapsed := time.Since(start)
+
+	// The batch must fail fast (configured call timeout), not block for
+	// the 31s the manager hardcoded before it was configurable.
+	assert.Less(t, elapsed, 5*time.Second)
+
+	var outputMessages []messages.Message
+	timeout := time.After(time.Second)
+	for len(outputMessages) < 2 {
+		select {
+		case msg := <-outputChan:
+			outputMessages = append(outputMessages, msg)
+		case <-timeout:
+			t.Fatal("Timeout waiting for output messages")
+		}
+	}
+
+	// Messages are nacked with their bodies untouched.
+	assert.True(t, outputMessages[0].IsNacked())
+	assert.True(t, outputMessages[1].IsNacked())
+	assert.Equal(t, []byte("test1"), outputMessages[0].Body)
+	assert.Equal(t, []byte("test2"), outputMessages[1].Body)
+}
+
 func TestMiddlewareManager_IsMiddlewareNotAvailable(t *testing.T) {
 	inputChan := make(chan messages.Message, 10)
 	outputChan := make(chan messages.Message, 10)
 
 	t.Run("MiddlewareNotAvailable", func(t *testing.T) {
-		manager := NewMiddlewareManager(inputChan, outputChan, "", 3, time.Second)
+		manager := NewMiddlewareManager(inputChan, outputChan, "", 3, time.Second, time.Second)
 		assert.True(t, manager.isMiddlewareNotAvailable())
 	})
 
 	t.Run("MiddlewareAvailable", func(t *testing.T) {
-		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, time.Second)
+		manager := NewMiddlewareManager(inputChan, outputChan, "localhost:8080", 3, time.Second, time.Second)
 		assert.False(t, manager.isMiddlewareNotAvailable())
 	})
 }
@@ -654,13 +698,15 @@ func TestNewMiddlewareManager(t *testing.T) {
 	address := "localhost:8080"
 	batchSize := 5
 	batchTimeout := 2 * time.Second
+	callTimeout := 10 * time.Second
 
-	manager := NewMiddlewareManager(inputChan, outputChan, address, batchSize, batchTimeout)
+	manager := NewMiddlewareManager(inputChan, outputChan, address, batchSize, batchTimeout, callTimeout)
 
 	assert.NotNil(t, manager)
 	assert.Equal(t, address, manager.MiddlewareAddress)
 	assert.Equal(t, batchSize, manager.BatchSize)
 	assert.Equal(t, batchTimeout, manager.BatchTimeout)
+	assert.Equal(t, callTimeout, manager.CallTimeout)
 	// Note: We can't directly compare channels due to type differences (bidirectional vs directional)
 	// but we can verify the manager was created with the correct channels by testing functionality
 	assert.NotNil(t, manager.InputChannel)


### PR DESCRIPTION
## What

Expose the middleware call timeout as `MIDDLEWARE_CALL_TIMEOUT_MS` (default `31000` — identical behavior to today's hardcoded `31*time.Second` in `MiddlwareManager.processMessageBatch`), and add the regression test #22 was missing.

## Why now

While triaging #22 I verified the two symptoms it reports were already fixed by later work (`WaitForReady` + retry policy from the batch-processing rewrite, and `8c610e2` *only use middleware data on success*), and measured the current behavior empirically with the new test: an unreachable middleware blocks the batch for **exactly 31.0s**, then nacks it with intact bodies — no crash, no body corruption. That 31s was untunable and untestable; making it configurable lets deployments choose how aggressively to shed load during a middleware outage, and lets the test run in 300ms instead of 31s.

Scope note: `UnimplementedMiddleware.Next()` (the middleware-SDK side) keeps its own 31s — this PR only touches the manager (homing-pigeon calling the first middleware), which is what #22 is about. The remaining design question on #22 (nack-to-DLQ vs backpressure during long outages) is left there for maintainers.

## Verification

- New test `TestMiddlewareManager_ProcessMessageBatch_MiddlewareUnreachable`: written first against the hardcoded timeout and watched fail (`"31.001276125s" is not less than "5s"`), green after wiring the configurable timeout.
- `go test -race -count=1 ./...` green.

refs #22 · Jira: [TECH-2662](https://softonic-development.atlassian.net/browse/TECH-2662) (context)


[TECH-2662]: https://softonic-development.atlassian.net/browse/TECH-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ