### PR TITLE
docs: document the middleware chains, contract and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,68 @@ message the writer nacked (there is no un-nack in the protocol) and they never s
 writer's backend response (e.g. the Elasticsearch bulk response). A failing middleware call
 nacks the whole batch.
 
+### Middlewares
+
+```
+  AMQP
+   |
+  Request ──> Middleware ──> Middleware ──> … ──> Middleware
+   |
+Elasticsearch
+   |
+  Response ──> Middleware ──> Middleware ──> … ──> Middleware
+   |
+  AMQP
+```
+
+There are two independent chains:
+
+- **Request middlewares** run between the reader and the writer, and are the place to
+  transform or enrich message bodies before they reach the write adapter.
+- **Response middlewares** run between the writer and the reader, once each message already
+  carries its `acked`/`nacked` outcome, and are the place to react to it (e.g. purge a cache
+  for successfully written documents). At this point mutating the body has no effect on what
+  was written.
+
+#### How the chain works
+
+Each middleware is a gRPC server implementing the `Middleware` service from
+[`proto/middleware.proto`](proto/middleware.proto) (`Handle(Data) returns (Data)`), listening
+on a Unix socket. Homing Pigeon only knows the **first** middleware of each chain
+(`REQUEST_MIDDLEWARES_SOCKET` / `RESPONSE_MIDDLEWARES_SOCKET`); chaining is nested — each
+middleware processes the batch, forwards it to the next one through its `OUT_SOCKET` (it
+listens on `IN_SOCKET`), and returns the final result back up the chain.
+
+Messages are sent in batches of up to `MIDDLEWARE_BATCH_SIZE`, waiting at most
+`MIDDLEWARE_BATCH_TIMEOUT_MS` to fill one.
+
+#### The contract
+
+A middleware receives `Data.messages` (`Id`, `Body`, `acked`, `nacked`) and must answer with
+the **same number of messages, with the same ids, in the same order**. It may:
+
+- mutate `Body` (request chain);
+- set `nacked: true` to reject a message.
+
+It can **not** ack messages (`acked` in the response is ignored — only the writer acks), and
+it can not un-nack a message. Any protocol violation — an error response, a length mismatch
+or an id mismatch — nacks the **whole batch**. If the middleware is unreachable, the call
+waits for it to become ready and retries on `UNAVAILABLE` (5 attempts with backoff) up to the
+call timeout (31s by default); on expiry the batch is nacked.
+
+#### Writing and deploying one
+
+- **Go**: implement `proto.MiddlewareServer`; the
+  [`pkg/middleware.UnimplementedMiddleware`](pkg/middleware/unimplemented.go) helper provides
+  `Listen()` (socket setup) and `Next()` (forwarding to the next middleware). See
+  [hp-pass-middleware](https://github.com/softonic/hp-pass-middleware) for a minimal
+  passthrough example.
+- **Any other language**: implement the service from `proto/middleware.proto` over a Unix
+  socket, honoring the contract above.
+- **Kubernetes**: the [Helm chart](https://github.com/softonic/homing-pigeon-chart) runs
+  middlewares as sidecar containers (`requestMiddlewares` / `responseMiddlewares` values) and
+  wires all the sockets automatically through a shared volume.
+
 ### Currently implemented interfaces
 
 #### Read interfaces

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ nacks the whole batch.
 ### Middlewares
 
 ```
-  AMQP
+  Reader adapter (e.g. AMQP)
    |
   Request ──> Middleware ──> Middleware ──> … ──> Middleware
    |
-Elasticsearch
+  Writer adapter (e.g. Elasticsearch)
    |
   Response ──> Middleware ──> Middleware ──> … ──> Middleware
    |
-  AMQP
+  Reader adapter (e.g. AMQP)
 ```
 
 There are two independent chains:
@@ -79,17 +79,18 @@ the **same number of messages, with the same ids, in the same order**. It may:
 - set `nacked: true` to reject a message.
 
 It can **not** ack messages (`acked` in the response is ignored — only the writer acks), and
-it can not un-nack a message. Any protocol violation — an error response, a length mismatch
-or an id mismatch — nacks the **whole batch**. If the middleware is unreachable, the call
-waits for it to become ready and retries on `UNAVAILABLE` (5 attempts with backoff) up to the
-call timeout (31s by default); on expiry the batch is nacked.
+it can not un-nack a message. An error response or a length mismatch nacks the **whole
+batch**; an id mismatch nacks **only that message**, the rest of the batch keeps its returned
+outcome. If the middleware is unreachable, the call waits for it to become ready and retries
+on `UNAVAILABLE` (5 attempts with backoff) up to the call timeout
+(`MIDDLEWARE_CALL_TIMEOUT_MS`, 31s by default); on expiry the batch is nacked.
 
 #### Writing and deploying one
 
 - **Go**: implement `proto.MiddlewareServer`; the
   [`pkg/middleware.UnimplementedMiddleware`](pkg/middleware/unimplemented.go) helper provides
   `Listen()` (socket setup) and `Next()` (forwarding to the next middleware). See
-  [hp-pass-middleware](https://github.com/softonic/hp-pass-middleware) for a minimal
+  [hp-passthrough](https://github.com/softonic/hp-passthrough) for a minimal
   passthrough example.
 - **Any other language**: implement the service from `proto/middleware.proto` over a Unix
   socket, honoring the contract above.


### PR DESCRIPTION
## What

New `### Middlewares` section in the README covering what #21 asked for: the request/response chains (with the diagram from the issue), how nested chaining over Unix sockets works (`IN_SOCKET`/`OUT_SOCKET`, batching), the `Handle(Data)` contract (same count/ids/order, nack-only, no un-nack, violations nack the whole batch, retry/timeout behavior when unreachable), and how to write one (Go via `UnimplementedMiddleware` / hp-pass-middleware, any language via the proto) and deploy it (chart sidecars).

Closes #21.

## Why now

#21 has been open since 2024 and the recently merged flow/semantics docs (#39) only covered middlewares in passing. Everything stated here is verified against the current code (`pkg/middleware/manager.go`, `pkg/middleware/unimplemented.go`, `proto/middleware.proto`) and the chart's socket wiring.

## Verification

Docs-only change; CI green means nothing was broken by it. The timeout wording ("31s by default") stays accurate if #42 (configurable call timeout) merges.
